### PR TITLE
3 | Adding Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hello! ![hi](media/norrisWave.gif)
+# Hello! ![lando norris waving](media/norrisWave.gif)
 
 📍 New Jersey<br>
 ⏳ Looking for a new opportunities<br>
@@ -20,7 +20,7 @@ were some of my favorite professional projects.
 Currently looking for new job opportunities to grow as a person and a professional. While my experience lies in backend,
 I have a desire to learn more and expand my horizons, making me open to just about anything.
 
-## 🔧 Technologies & Tools
+## 🧰 Technologies & Tools
 
 [![Java](https://img.shields.io/badge/Java-%23ED8B00.svg?logo=openjdk&logoColor=white)](#)
 [![Python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=fff)](#)
@@ -40,7 +40,92 @@ I have a desire to learn more and expand my horizons, making me open to just abo
 [![Confluence](https://img.shields.io/badge/Confluence-172B4D?logo=confluence&logoColor=fff)](#)
 [![ReadMe](https://img.shields.io/badge/ReadMe-018EF5?logo=readme&logoColor=fff)](#)
 [![Notion](https://img.shields.io/badge/Notion-000?logo=notion&logoColor=fff)](#)
+![LaTeX](https://img.shields.io/badge/latex-%23008080.svg?logo=latex&logoColor=white)
 [![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?logo=intellij-idea&logoColor=white)](#)
+
+## 🛠️ Projects
+
+### 🎵 [Rhythmic Radiance](https://github.com/Kuneho-Studios/beatmap-devtool) - a beatmap developer tool for our multi-lane rhythm game 
+[![Python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=fff)](#)
+[![Unreal Engine](https://img.shields.io/badge/Unreal%20Engine-%23313131.svg?logo=unrealengine&logoColor=white)](#)
+[![C++](https://img.shields.io/badge/C++-%2300599C.svg?logo=c%2B%2B&logoColor=white)](#)
+[![PyCharm](https://img.shields.io/badge/PyCharm-000?logo=pycharm&logoColor=fff)](#)
+[![Visual Studio](https://custom-icon-badges.demolab.com/badge/Visual%20Studio-5C2D91.svg?&logo=visualstudio&logoColor=white)](#)
+[![Rider](https://img.shields.io/badge/Rider-000?logo=rider&logoColor=fff)](#)
+[![GitHub](https://img.shields.io/badge/GitHub-%23121011.svg?logo=github&logoColor=white)](#)
+[![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?logo=github-actions&logoColor=white)](#)
+
+Rhythmic Radiance is a multi-lane rhythm game in development by Kuneho Studios, a games company that I started with 
+some friends of mine. I serve as a lead UI/UX engineer for our development team in Unreal Engine. In designing a 
+diegetic UI, I work with data tables and structs to organize and display our data. Additionally, I have designed a 
+random item drop system that rewards our players with items after completing a level. Game development is not what I 
+went to school for, however, I felt that learning a new game engine and programming language would help me strengthen 
+my software development skills. Through all of this, I believe my biggest contribution is through our Python beatmap 
+developer tool.
+
+The crux of our game relies on beatmaps, which are the way to translate the song into notes that appear on the play 
+screen for the user to strike. Think Guitar Hero and how the notes come down the screen to the user in lanes. As the 
+names and methods used to display this in-engine are not required knowledge for the individual who is beatmapping a 
+song, I wanted to abstract that out. The developer tool accomplishes this with a prompt-based system. I wrote a Python 
+program that gives the user options that they can select to develop a valid music chart (through a JSON file) that can 
+be read in Unreal Engine. The tool is a flexible program that allows users to create, read, update, and delete beatmaps 
+as they so choose, without ever needing to go into Unreal Engine.
+
+The developer tool is a living program that will be updated as the game matures. I am also looking for new ways to 
+improve the user experience and allow more advanced users to perform actions more efficiently.
+
+You can [visit our website](https://www.kunehostudios.com/) to learn more and subscribe to our mailing list!
+
+### 🎮 [ARI](https://github.com/jlmcdonough/SENDHELP) - a cybersecurity training escape room experience
+[![Unity](https://img.shields.io/badge/Unity-%23000000.svg?logo=unity&logoColor=white)](#)
+[![C#](https://custom-icon-badges.demolab.com/badge/C%23-%23239120.svg?logo=cshrp&logoColor=white)](#)
+[![Visual Studio](https://custom-icon-badges.demolab.com/badge/Visual%20Studio-5C2D91.svg?&logo=visualstudio&logoColor=white)](#)
+[![GitHub](https://img.shields.io/badge/GitHub-%23121011.svg?logo=github&logoColor=white)](#)
+
+ARI is an educational first-person puzzle escape room game designed to teach best cybersecurity practices to all 
+audiences. The goal was to create an enjoyable learning experience through interactive gameplay while simultaneously 
+providing a robust introductory cybersecurity education.
+
+To complete both a software development and a cybersecurity degree at Marist, undergraduates had to complete a 
+"capstone project" which was meant to encompass their previous 4 years of learning. To graduate, a double major must 
+complete two capstones. I was fortunate enough that there was an opportunity that would allow me to combine and do both. 
+Through ARI, I was able to be a critical contributor to both teams. As a member of the software development team, I 
+learned a new programming language (C#) and a game engine (Unity). I developed many cybersecurity-centric minigames 
+that would be implemented and brought ARI to life. In leading the cybersecurity team, I was responsible for the 
+narrative direction and level design of the game. Being a part of both teams allowed me to relay requirements easily 
+between the two and helped alleviate any blockers as they appeared.
+
+Having exceeded our professors' expectations, they recommended that we present our game and corresponding paper on the 
+gamification of learning and the 
+[octalysis framework](https://yukaichou.com/gamification-examples/octalysis-complete-gamification-framework/) at the 
+[Mid-Hudson Regional Business Plan Competition](https://www.marist.edu/computer-science-math/mid-hudson-regional-business-plan-competition) 
+and later the [14th Annual ECC Conference](https://ecc.marist.edu/web/conference2022). At the ECC Conference, we won
+the cybersecurity award for best in its category, competing against other established cybersecurity individuals and 
+teams. Afterward, we licensed ARI to be used in a high school cybersecurity summer class where students were able to 
+play our game and talk to us about it and cybersecurity as a whole.
+
+You can [watch our trailer](https://www.youtube.com/watch?v=d_8eWLMA32Y) or 
+even [download]((https://sendhelp-studios.itch.io/ari)) and play ARI yourself!
+
+[//]: # ( ### 🚖 Robotics Course [here]&#40;https://github.com/jlmcdonough/Robotics&#41;)
+
+### 🖥️  [rhinOS](https://github.com/jlmcdonough/Operating-Systems) - a browser-based operating system in TypeScript 
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff)](#)
+[![HTML](https://img.shields.io/badge/HTML-%23E34F26.svg?logo=html5&logoColor=white)](#)
+[![CSS](https://img.shields.io/badge/CSS-639?logo=css&logoColor=fff)](#)
+[![LaTeX](https://img.shields.io/badge/latex-%23008080.svg?logo=latex&logoColor=white)](#)
+[![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?logo=intellij-idea&logoColor=white)](#)
+[![GitHub](https://img.shields.io/badge/GitHub-%23121011.svg?logo=github&logoColor=white)](#)
+
+rhinOS is a browser-based operating system that is written in TypeScript, developed in an operating systems course 
+during my senior year of college. The project was a culmination of all the course material into one, runnable operating 
+system. rhinOS can still be run ([here](https://jlmcdonough.github.io/Operating-Systems/)).
+
+rhinOS allows the user to load 6502a machine language opcodes into memory, execute one or more programs continuously, 
+and to create, read, write, delete, execute, copy, rename, and list text files. The application supports a light and 
+dark mode too. A test directory was supplied to provide examples to test the functionality of the operating system. 
+rhinOS has a 100% pass rate.
+
 
 ## 📷 Outside Interests
 
@@ -56,4 +141,4 @@ Also playing video games like Counter-Strike where I recorded every game I playe
 
 [![LinkedIn Badge](https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff)](https://www.linkedin.com/in/josephl-mcdonough/)
 
-![europaLeague2025](media/sonEuropa.gif)
+![son heung-min with europa 2025 trophy](media/sonEuropa.gif)


### PR DESCRIPTION
### Summary 
- Added a `Projects` section that includes some of my bigger projects
  - Some tools used in those projects are present as well as links to their repos

### Testing
- [x] Rhythmic Radiance link opens the dev tool repo
- [x] "visit our website" leads to kunehostudios.com
- [x] ARI link opens the ARI repo
- [x] "octalysis framework" leads to its site
- [x] "Mid-Hudson Regional Business Plan Competition" leads to the correct page
- [x] "14th Annual ECC Conference" leads to its correct page
- [x] "watch our trailer" leads to the ARI trailer on youtube
- [x] "download" leads to ARI's itch.io page
- [x] rhinOS link leads to its GitHub repo
- [x] "here" leads to the runnable rhinOS GitHub pages site        

Closes #3 